### PR TITLE
V4.4.0.1

### DIFF
--- a/formats/V4.4.0/write_csv_naming.sh
+++ b/formats/V4.4.0/write_csv_naming.sh
@@ -36,6 +36,7 @@ sed 's/  /,/g;s/R N/R,N/; s/,,/,/g; s/,,/,/g; s/,,/,/g; s/, /,/g' column_definit
 
 # create ascii doc version
 asciifile=lehd_csv_naming.asciidoc
+previousvintage=$(cd ..; ls -1d * | grep -E "V[0-9]" | tail -2 | head -1)
 echo "= LEHD Public Use  Schema $numversion - File and Directory Naming Convention"> $asciifile
 echo "Lars Vilhuber <${author}>" >> $asciifile
 echo "$(date +%d\ %B\ %Y)
@@ -54,7 +55,7 @@ echo "
 .Important
 ==============================================
 This document is not an official Census Bureau publication. It is compiled from publicly accessible information
-by Lars Vilhuber (http://www.ilr.cornell.edu/ldi/[Labor Dynamics Institute, Cornell University]).
+by Lars Vilhuber (https://www.ilr.cornell.edu/ldi/[Labor Dynamics Institute, Cornell University]).
 Feedback is welcome. Please write us at
 link:mailto:${author}?subject=LEHD_Schema_v4[${author}].
 ==============================================
@@ -87,7 +88,7 @@ Purpose
 The public-use data from the Longitudinal Employer-Household Dynamics Program, including the Quarterly Workforce Indicators (QWI)
 and Job-to-Job Flows (J2J), are available for download with the following data schema.
 These data are available as Comma-Separated Value (CSV) files through the LEHD website’s Data page at
-http://lehd.ces.census.gov/data/ and through LED Extraction Tool at http://ledextract.ces.census.gov/.
+https://lehd.ces.census.gov/data/ and through LED Extraction Tool at https://ledextract.ces.census.gov/.
 
 This document describes the file and directory naming schema for LEHD-provided CSV files.
 
@@ -103,7 +104,7 @@ This version modifies a portion of the structure of the metadata. Many files com
 
 Supersedes
 ----------
-This version supersedes V4.2, for files released as of R2018Q3
+This version supersedes ${previousvintage}
 
 
 Basic Filename Schema
@@ -123,6 +124,7 @@ some other identifier.
 cat naming_convention.csv | sed 's+_+\\_+g' | sed 's+\\_\[id\]+_[id]+' |
  sed 's+\\_\[sa\]+_[sa]+' | sed 's+\\_\[geocat\]\.zip+_[geocat].zip+' |
  sed 's+\\_\[fas\]\.+_[fas].+' | sed 's+\\_\[geography\]\\_+_[geography]_+' > tmp_naming_convention.csv
+
 echo "
 [width=\"90%\",format=\"csv\",delim=\",\",cols=\"^1,<3,<5\",options=\"header\"]
 |===================================================
@@ -130,7 +132,7 @@ include::tmp_naming_convention.csv[]
 |===================================================
 
 === QWIPU from the LED Extraction Tool
-Files downloaded through the  LED Extraction Tool at http://ledextract.ces.census.gov/ follow the following naming convention:
+Files downloaded through the  LED Extraction Tool at https://ledextract.ces.census.gov/ follow the following naming convention:
 ....................................
  [type]_[id].[EXT]
 ....................................

--- a/formats/V4.4.0/write_schemadoc.sh
+++ b/formats/V4.4.0/write_schemadoc.sh
@@ -63,7 +63,7 @@ case $version in
 .Important
 ==============================================
 This document is not an official Census Bureau publication. It is compiled from publicly accessible information
-by Lars Vilhuber (http://www.ilr.cornell.edu/ldi/[Labor Dynamics Institute, Cornell University]).
+by Lars Vilhuber (https://www.ilr.cornell.edu/ldi/[Labor Dynamics Institute, Cornell University]).
 Feedback is welcome. Please write us at
 link:mailto:lars.vilhuber@cornell.edu?subject=LEHD_Schema_v4[lars.vilhuber@cornell.edu].
 ==============================================
@@ -95,7 +95,7 @@ Purpose
 The public-use data from the Longitudinal Employer-Household Dynamics Program, including the Quarterly Workforce Indicators (QWI)
 and Job-to-Job Flows (J2J), are available for download with the following data schema.
 These data are available  through the LEHD website’s Data page at
-http://lehd.ces.census.gov/data/ and through the LED Extraction Tool at http://ledextract.ces.census.gov/.
+https://lehd.ces.census.gov/data/ and through the LED Extraction Tool at https://ledextract.ces.census.gov/.
 
 This document describes the data schema for LEHD files. LEHD-provided SHP files are separately described in link:lehd_shapefiles{ext-relative}[]. For each variable,
 a set of allowable values is defined. Definitions are provided as CSV files,
@@ -111,7 +111,7 @@ This version reimplements some features from  V4.0. Many files compliant with LE
 
 Supersedes
 ----------
-This version supersedes ${previousvintage}, for files released as of ${versionvintage}.
+This version supersedes ${previousvintage}
 
 Basic Schema
 ------------
@@ -440,7 +440,7 @@ echo "
 Only a small subset of available values shown.
 The 2017 NAICS (North American Industry Classification System) is used for all years.
 QWI releases prior to R2018Q1 used the 2012 NAICS classification (see link:../V4.1.3[Schema v4.1.3]).
-For a full listing of all valid 2017 NAICS codes, see http://www.census.gov/cgi-bin/sssd/naics/naicsrch?chart=2017.
+For a full listing of all valid 2017 NAICS codes, see https://www.census.gov/cgi-bin/sssd/naics/naicsrch?chart=2017.
 
 [width=\"90%\",format=\"csv\",cols=\"^1,<5,^1\",options=\"header\"]
 |===================================================

--- a/formats/V4.4.0/write_schemadoc.sh
+++ b/formats/V4.4.0/write_schemadoc.sh
@@ -41,8 +41,8 @@ versionvintage=R2018Q3
 # versionj2jvintage=$versionvintage
 versionj2jvintage=R2018Q2
 versionstate=de
-versionurl=https://lehd.ces.census.gov/data/qwi/$versionvintage/$versionstate
-versionj2jurl=https://lehd.ces.census.gov/data/j2j/$versionj2jvintage/j2j/$versionstate
+versionurl=https://lehd.ces.census.gov/data/qwi/${versionvintage}/${versionstate}
+versionj2jurl=https://lehd.ces.census.gov/data/j2j/${versionj2jvintage}/${versionstate}/j2j
 previousvintage=$(cd ..; ls -1d * | grep -E "V[0-9]" | tail -2 | head -1)
 
 

--- a/formats/V4.4.0/write_schemadoc.sh
+++ b/formats/V4.4.0/write_schemadoc.sh
@@ -592,6 +592,8 @@ echo "...,,,,,,,,,,,,,,,,,,,,,," >> $nsfileshort
 head -31 $nsfile | tail -3 >> $nsfileshort
 echo "...,,,,,,,,,,,,,,,,,,,,,," >> $nsfileshort
 
+tmp_nsfileshort_csv=$(mktemp -p $cwd)
+cut -d ',' -f 1-9 $nsfileshort >> $tmp_nsfileshort_csv
 echo "
 <<<
 === Aggregation level
@@ -621,7 +623,7 @@ A shortened representation of the file is provided below, the complete file is a
 
 [width=\"90%\",format=\"csv\",cols=\">1,3*<2,5*<1\",options=\"header\"]
 |===================================================
-include::$nsfileshort[]
+include::$tmp_nsfileshort_csv[]
 |===================================================
 ">> $asciifile
 

--- a/formats/V4.4.0/write_schemadoc.sh
+++ b/formats/V4.4.0/write_schemadoc.sh
@@ -43,10 +43,8 @@ versionj2jvintage=R2018Q2
 versionstate=de
 versionurl=https://lehd.ces.census.gov/data/qwi/$versionvintage/$versionstate
 versionj2jurl=https://lehd.ces.census.gov/data/j2j/$versionj2jvintage/j2j/$versionstate
-
 previousvintage=$(cd ..; ls -1d * | grep -E "V[0-9]" | tail -2 | head -1)
 
-echo "DEBUG TEST " $cwd
 
 echo "= LEHD Public Use Data Schema $numversion" > $asciifile
 echo "Lars Vilhuber <${author}>" >> $asciifile
@@ -496,6 +494,8 @@ done
 for arg in   $(ls label_geo_level*csv)
 do
   name="$(echo ${arg%*.csv}| sed 's/label_//')"
+	tmp_geo_csv=$(mktemp -p $cwd)
+	cut -d ',' -f 1,2,3 $arg >> $tmp_geo_csv
   echo "[[$name]]
 ==== [[geolevel]] Geographic levels
 Geography labels for data files are provided in separate files, by scope. Each file 'label_geograpy_SCOPE.csv' may contain one or more types of records as flagged by <<geolevel,geo_level>>. For convenience, a composite file containing all geocodes is available as link:label_geography.csv[].
@@ -507,9 +507,9 @@ Shapefiles are described in a link:lehd_shapefiles{ext-relative}[separate docume
 
 ( link:${arg}[] )
 
-[width=\"80%\",format=\"csv\",cols=\"^1,<3,<8,<8\",options=\"header\"]
+[width=\"80%\",format=\"csv\",cols=\"^1,<3,<8\",options=\"header\"]
 |===================================================
-include::$arg[]
+include::$tmp_geo_csv[]
 |===================================================
 " >> $asciifile
 done
@@ -741,4 +741,5 @@ asciidoctor-pdf -a pdf-page-size=letter -a icons -a toc -a numbered -a outfilesu
 #html2text $(basename $asciifile .asciidoc).html > $(basename $asciifile .asciidoc).txt
 #[[ -f $(basename $asciifile .asciidoc).txt  ]] && echo "$(basename $asciifile .asciidoc).txt created"
 echo "Removing tmp files"
+rm -f $cwd/tmp.* #remove files made by mktemp
 #rm tmp*

--- a/formats/V4.4.0/write_schemadoc.sh
+++ b/formats/V4.4.0/write_schemadoc.sh
@@ -507,7 +507,7 @@ Shapefiles are described in a link:lehd_shapefiles{ext-relative}[separate docume
 
 ( link:${arg}[] )
 
-[width=\"80%\",format=\"csv\",cols=\"^1,<3,<8\",options=\"header\"]
+[width=\"90%\",format=\"csv\",cols=\"^1,<3,<8\",options=\"header\"]
 |===================================================
 include::$tmp_geo_csv[]
 |===================================================

--- a/formats/V4.4.0/write_schemadoc.sh
+++ b/formats/V4.4.0/write_schemadoc.sh
@@ -44,6 +44,10 @@ versionstate=de
 versionurl=https://lehd.ces.census.gov/data/qwi/$versionvintage/$versionstate
 versionj2jurl=https://lehd.ces.census.gov/data/j2j/$versionj2jvintage/j2j/$versionstate
 
+previousvintage=$(cd ..; ls -1d * | grep -E "V[0-9]" | tail -2 | head -1)
+
+echo "DEBUG TEST " $cwd
+
 echo "= LEHD Public Use Data Schema $numversion" > $asciifile
 echo "Lars Vilhuber <${author}>" >> $asciifile
 echo "$(date +%d\ %B\ %Y)
@@ -109,7 +113,7 @@ This version reimplements some features from  V4.0. Many files compliant with LE
 
 Supersedes
 ----------
-This version supersedes V4.2.0, for files released as of R2018Q3.
+This version supersedes ${previousvintage}, for files released as of ${versionvintage}.
 
 Basic Schema
 ------------

--- a/formats/V4.4.0/write_schemadoc.sh
+++ b/formats/V4.4.0/write_schemadoc.sh
@@ -514,6 +514,9 @@ include::$tmp_geo_csv[]
 " >> $asciifile
 done
 
+
+tmp_stusps_csv=$(mktemp -p $cwd)
+cut -d ',' -f 1,2 label_stusps.csv >> $tmp_stusps_csv
 echo "
 
 ==== [[geostate]]National and state-level values ====
@@ -533,9 +536,9 @@ Some parts of the schema use (lower or upper-case) state postal codes.
 
 ( link:label_stusps.csv[] )
 
-[width=\"60%\",format=\"csv\",cols=\"^1,<4\",options=\"header\"]
+[width=\"40%\",format=\"csv\",cols=\"^1,<2\",options=\"header\"]
 |===================================================
-include::label_stusps.csv[]
+include::$tmp_stusps_csv[]
 |===================================================
 
 

--- a/formats/V4.4.0/write_shapefiles.sh
+++ b/formats/V4.4.0/write_shapefiles.sh
@@ -131,7 +131,7 @@ https://ledextract.ces.census.gov/[LED Extraction Tool].
 
 Shapefiles are used to provide mapping functionality in https://qwiexplorer.ces.census.gov/[QWI Explorer] and https://j2jexplorer.ces.census.gov/[Job-to-Job Explorer (Beta)].
 They are created by transforming input shapefiles sourced from https://www.census.gov/geo/maps-data/data/tiger-line.html[TIGER/Line].
-New TIGER/Line shapefiles are typically released by the Census Bureau's Geography Division in August of each year, which are then processed by the LEHD program as new tabulation areas for the QWI[https://lehd.ces.census.gov/data/#qwi] and J2J[https://lehd.ces.census.gov/data/#j2j] data products. The LEHD shapefiles will be made available in the data schema in coordination with the public release of QWI and J2J data products, usually in November or December of each year.
+New TIGER/Line shapefiles are typically released by the Census Bureau's Geography Division in August of each year, which are then processed by the LEHD program as new tabulation areas for the https://lehd.ces.census.gov/data/#qwi[QWI] and https://lehd.ces.census.gov/data/#j2j[J2J] data products. The LEHD shapefiles will be made available in the data schema in coordination with the public release of QWI and J2J data products, usually in November or December of each year.
 
 Sources
 -------

--- a/formats/V4.4.0/write_shapefiles.sh
+++ b/formats/V4.4.0/write_shapefiles.sh
@@ -197,7 +197,9 @@ FIPS State Postal Code as per https://www.census.gov/geo/reference/codes/cou.htm
 The valid codes correspond to those listed on link:label_geography.csv[].
 
 ==== NAME
-This is a string that corresponds in general to the 'label' field on link:label_geography.csv[] and link:label_geography_metro.csv[]. Minor deviations for ease of exposition are possible.
+( link:label_geography.csv[] )
+
+This is a string that corresponds in general to the 'label' field on link:label_geography.csv[]. Minor deviations for ease of exposition are possible.
 
 === Common files
 ==== State

--- a/formats/V4.4.0/write_shapefiles.sh
+++ b/formats/V4.4.0/write_shapefiles.sh
@@ -164,7 +164,7 @@ Basic Naming Schema
 All files follow the following naming convention:
 
 --------------------------------
-[type]]_[geocat].zip
+[type]_[geocat].zip
 --------------------------------
 
 where [type] = lehd_shp and link:naming_geocat.csv[geocat] contains

--- a/formats/V4.4.0/write_shapefiles.sh
+++ b/formats/V4.4.0/write_shapefiles.sh
@@ -54,7 +54,7 @@ case $version in
 .Important
 ==============================================
 This document is not an official Census Bureau publication. It is compiled from publicly accessible information
-by Lars Vilhuber (http://www.ilr.cornell.edu/ldi/[Labor Dynamics Institute, Cornell University]).
+by Lars Vilhuber (https://www.ilr.cornell.edu/ldi/[Labor Dynamics Institute, Cornell University]).
 Feedback is welcome. " >> $asciifile
 	;;
 	draft|*)
@@ -126,28 +126,28 @@ link:lehd_public_use_schema{ext-relative}[structural] and
 link:lehd_csv_naming{ext-relative}[file naming] schema.
 The data themselves are available as
 Comma-Separated Value (CSV) files through the LEHD website's Data page
-at http://lehd.ces.census.gov/data/ as well as through the
-http://ledextract.ces.census.gov/[LED Extraction Tool].
+at https://lehd.ces.census.gov/data/ as well as through the
+https://ledextract.ces.census.gov/[LED Extraction Tool].
 
-Shapefiles are used to provide mapping functionality in http://qwiexplorer.ces.census.gov/[QWI Explorer] and https://j2jexplorer.ces.census.gov/[Job-to-Job Explorer (Beta)].
+Shapefiles are used to provide mapping functionality in https://qwiexplorer.ces.census.gov/[QWI Explorer] and https://j2jexplorer.ces.census.gov/[Job-to-Job Explorer (Beta)].
 They are created by transforming input shapefiles sourced from https://www.census.gov/geo/maps-data/data/tiger-line.html[TIGER/Line].
-New TIGER/Line shapefiles are typically released by the Census Bureau's Geography Division in August of each year, which are then processed by the LEHD program as new tabulation areas for the QWI[http://lehd.ces.census.gov/data/#qwi] and J2J[http://lehd.ces.census.gov/data/#j2j] data products. The LEHD shapefiles will be made available in the data schema in coordination with the public release of QWI and J2J data products, usually in November or December of each year.
+New TIGER/Line shapefiles are typically released by the Census Bureau's Geography Division in August of each year, which are then processed by the LEHD program as new tabulation areas for the QWI[https://lehd.ces.census.gov/data/#qwi] and J2J[https://lehd.ces.census.gov/data/#j2j] data products. The LEHD shapefiles will be made available in the data schema in coordination with the public release of QWI and J2J data products, usually in November or December of each year.
 
 Sources
 -------
 Files are derived from   https://www.census.gov/geo/maps-data/data/tiger-line.html[TIGER/Line 2017 shapefiles]:
 
-* http://www2.census.gov/geo/tiger/TIGER2017/STATE/[tl_2017_us_state]
-* http://www2.census.gov/geo/tiger/TIGER2017/COUNTY/[tl_2017_us_county]
-* http://www2.census.gov/geo/tiger/TIGER2017/CBSA/[tl_2017_us_cbsa]
-* http://www2.census.gov/geo/tiger/TIGER2017/PLACE/[tl_2017_(ST)_place]  (for creation of WIA/WIB shapefile)
-* http://www2.census.gov/geo/tiger/TIGER2017/COUSUB/[tl_2017_(ST)_cousub] (for creation of WIA/WIB shapefile)
+* https://www2.census.gov/geo/tiger/TIGER2017/STATE/[tl_2017_us_state]
+* https://www2.census.gov/geo/tiger/TIGER2017/COUNTY/[tl_2017_us_county]
+* https://www2.census.gov/geo/tiger/TIGER2017/CBSA/[tl_2017_us_cbsa]
+* https://www2.census.gov/geo/tiger/TIGER2017/PLACE/[tl_2017_(ST)_place]  (for creation of WIA/WIB shapefile)
+* https://www2.census.gov/geo/tiger/TIGER2017/COUSUB/[tl_2017_(ST)_cousub] (for creation of WIA/WIB shapefile)
 
 Transformations
 ---------------
 The following major transformations are applied to the input files:
 
-* All geographies are reprojected to http://spatialreference.org/ref/epsg/wgs-84/[WGS-1984 Geographic Coordinate System]
+* All geographies are reprojected to https://spatialreference.org/ref/epsg/wgs-84/[WGS-1984 Geographic Coordinate System]
 * Shoreline water has been clipped out to provide a more recognizable depiction of the coastlines.
 * Each layer is given internal point coordinates (stored as double) based on the WGS-1984 projection (decimal degrees).
 * Each layer is run through a "simplify polygon" procedure to remove unnecessary complexity from the features.
@@ -178,7 +178,7 @@ include::naming_geocat.csv[]
 === [[format]] FORMAT
 ( link:variables_shp.csv[variables_shp.csv] )
 
-Files are distributed as http://www.digitalpreservation.gov/formats/fdd/fdd000280.shtml[ESRI Shapefiles], packaged as https://en.wikipedia.org/wiki/Zip_(file_format)[ZIP] files. The SHP component of these archives is described here. Other components (dbf, prj, shx) files are not documented here, we refer users to http://www.digitalpreservation.gov/formats/fdd/fdd000280.shtml .
+Files are distributed as https://www.digitalpreservation.gov/formats/fdd/fdd000280.shtml[ESRI Shapefiles], packaged as https://en.wikipedia.org/wiki/Zip_(file_format)[ZIP] files. The SHP component of these archives is described here. Other components (dbf, prj, shx) files are not documented here, we refer users to https://www.digitalpreservation.gov/formats/fdd/fdd000280.shtml .
 
 [width="60%",format="csv",cols="<2,<2,<5,<5",options="header"]
 |===================================================
@@ -234,7 +234,7 @@ The WIA/WIB shapefiles are built from the Place, County Subdivision, and County 
 Versioning
 ----------
 
-Versioning rules follow http://semver.org/spec/v2.0.0.html[Semantic
+Versioning rules follow https://semver.org/spec/v2.0.0.html[Semantic
 Versioning V2.0.0], which states that
 
 ________________________________________________________________________________

--- a/formats/V4.4.0/write_shapefiles.sh
+++ b/formats/V4.4.0/write_shapefiles.sh
@@ -193,6 +193,7 @@ FIPS State Postal Code as per https://www.census.gov/geo/reference/codes/cou.htm
 
 ==== GEOGRAPHY
 ( link:label_geography.csv[] )
+
 The valid codes correspond to those listed on link:label_geography.csv[] and link:label_geography_metro.csv[].
 
 ==== NAME

--- a/formats/V4.4.0/write_shapefiles.sh
+++ b/formats/V4.4.0/write_shapefiles.sh
@@ -194,7 +194,7 @@ FIPS State Postal Code as per https://www.census.gov/geo/reference/codes/cou.htm
 ==== GEOGRAPHY
 ( link:label_geography.csv[] )
 
-The valid codes correspond to those listed on link:label_geography.csv[] and link:label_geography_metro.csv[].
+The valid codes correspond to those listed on link:label_geography.csv[].
 
 ==== NAME
 This is a string that corresponds in general to the 'label' field on link:label_geography.csv[] and link:label_geography_metro.csv[]. Minor deviations for ease of exposition are possible.


### PR DESCRIPTION
Here are the changes from https://github.com/labordynamicsinstitute/qwi_schemas/issues/106

After a bit of time I punted on getting the extra escape characters out of /formats/V4.4.0/lehd_csv_naming.html#_basic_filename_schema. Here's Heath's original post on this:
- In the Filenaming Schema table: https://labordynamicsinstitute.github.io/qwi_schemas/formats/V4.4.0/lehd_csv_naming.html#_basic_filename_schema, there are three "\" in the 2nd row of the Type column and one in the 4th row (although this one appears in V4.3.1 as well) that look to be escaping underscores, but they should not appear in this table.


